### PR TITLE
Raise QueryStringInterface::MixedArgumentError to avoid implicit conv…

### DIFF
--- a/lib/query_string_interface/error.rb
+++ b/lib/query_string_interface/error.rb
@@ -1,4 +1,7 @@
 module QueryStringInterface
   class DateTimeParseError < ArgumentError
   end
+
+  class MixedArgumentError < ArgumentError
+  end
 end

--- a/lib/query_string_interface/filter.rb
+++ b/lib/query_string_interface/filter.rb
@@ -38,6 +38,10 @@ module QueryStringInterface
       raw_attribute == 'or'
     end
 
+    def or_value
+      @or_value ||= JSON.parse(raw_value) if or_attribute?
+    end
+
     def include?(other_filter)
       if or_attribute?
         json_value.any? do |filters|
@@ -63,8 +67,10 @@ module QueryStringInterface
           result[filter_operation] = filter_value
           result
         end
-      else
+      elsif !operator.nil? && !other_filter.operator.nil?
         @value = value.merge(other_filter.value)
+      else
+        raise MixedArgumentError, "arguments `#{raw_attribute}` and `#{other_filter.raw_attribute}` could not be mixed"
       end
     end
 

--- a/lib/query_string_interface/filter_collection.rb
+++ b/lib/query_string_interface/filter_collection.rb
@@ -53,7 +53,7 @@ module QueryStringInterface
       def optimized_filter_parsers
         if or_filter_parser
           if or_filter_parser.value.is_a?(Array) && or_filter_parser.value.count == 1
-            or_inner_filters = or_filter_parser.value.first.with_indifferent_access.map do |raw_attribute, raw_value|
+            or_inner_filters = or_filter_parser.or_value.first.with_indifferent_access.map do |raw_attribute, raw_value|
               Filter.new(raw_attribute, raw_value, @attributes_to_replace, @raw_filters)
             end
             filter_parsers.delete(or_filter_parser)

--- a/spec/query_string_interface/filter_spec.rb
+++ b/spec/query_string_interface/filter_spec.rb
@@ -389,6 +389,10 @@ describe QueryStringInterface::Filter do
       it "should merge other filter if they have an array conditional operator and their attribute is used in one of the or clauses" do
         subject.merge(other_filter).should eq([{'title' => 'Some Title', 'tags' => {'$all' => ['Other filter tag']}}, {'count' => { '$gte' => 1, '$lt' => 10 }, 'tags' => {'$all' => ['Other filter tag']}}, {'tags' => { '$all' => ['Some tag', 'Other tag', 'Other filter tag'], '$nin' => ["A tag", "Another tag"] }}])
       end
+
+      it "should not merge other filter if it does not have an operator" do
+        expect { subject.merge(described_class.new('tags', 'Problem tag')) }.to raise_error(QueryStringInterface::MixedArgumentError, "arguments `tags.all` and `tags` could not be mixed")
+      end
     end
 
     describe "normal filters" do

--- a/spec/query_string_interface/query_string_interface_spec.rb
+++ b/spec/query_string_interface/query_string_interface_spec.rb
@@ -334,6 +334,14 @@ describe QueryStringInterface do
                   :type => 'any'
                 }.with_indifferent_access
             end
+
+            it "should simplify the query" do
+              Document.filtering_options("tags.nin" => ["fluminense", "vasco"], 'or' => '[{"tags.all": ["flamengo", "basquete"], "type": "any"}, {"tags.all": ["botafogo", "volei"], "kind": "any"}]').should == {
+                  :tags => { :$nin => ["fluminense", "vasco"] },
+                  :$or => [{ :tags => { :$all => ["flamengo", "basquete"] }, :type => "any" }, { :tags => { :$all => ["botafogo", "volei"] }, :kind => "any" }],
+                  :status => 'published',
+                }.with_indifferent_access
+            end
           end
         end
 


### PR DESCRIPTION
…ersion error when merging values of different types

To avoid this kind of error:

```
INFO -- : Parameters: {"program_id.in"=>"5|6", "program_id"=>"7"}
ERROR -- : Params: {"program_id.in"=>"5|6", "program_id"=>"7", "controller"=>"videos", "action"=>"index"}
ERROR -- : no implicit conversion of Fixnum into Hash
```

And show a better message:

```
INFO -- : Parameters: {"program_id.in"=>"5|6", "program_id"=>"7"}
ERROR -- : Params: {"program_id.in"=>"5|6", "program_id"=>"7", "controller"=>"videos", "action"=>"index"}
ERROR -- : arguments `program_id.in` and `program_id` could not be mixed
```
